### PR TITLE
Explain that TokenOnChainInfo.symbol is an address

### DIFF
--- a/open-defi-api.yaml
+++ b/open-defi-api.yaml
@@ -1602,6 +1602,9 @@ components:
           type: string
         symbol:
           type: string
+          format: blockchain_address
+          description: >
+            NOTE: Currently a token address is returned as the token symbol.
         total_supply:
           type: string
           format: decimal


### PR DESCRIPTION
As per offline discussion. Token search should return token address, which can be used to fetch token details through the `/token/details` endpoint.