### PR TITLE
Fix logo URL

### DIFF
--- a/open-defi-api.yaml
+++ b/open-defi-api.yaml
@@ -8,7 +8,7 @@ info:
     email: mikko@tradingstrategy.ai
     url: 'https://tradingstrategy.ai'
   x-logo:
-    url: 'https://raw.githubusercontent.com/tradingstrategy-ai/frontend/master/src/lib/assets/logo-two-lines.svg'
+    url: 'https://raw.githubusercontent.com/tradingstrategy-ai/frontend/master/src/lib/assets/logo-horizontal-light.svg'
 
   description: |
 

--- a/trade-executor-api.yaml
+++ b/trade-executor-api.yaml
@@ -8,7 +8,7 @@ info:
     email: mikko@tradingstrategy.ai
     url: 'https://tradingstrategy.ai'
   x-logo:
-    url: 'https://raw.githubusercontent.com/tradingstrategy-ai/frontend/master/src/lib/assets/logo-two-lines.svg'
+    url: 'https://raw.githubusercontent.com/tradingstrategy-ai/frontend/master/src/lib/assets/logo-horizontal-light.svg'
 
   description: |
 


### PR DESCRIPTION
Towards https://github.com/tradingstrategy-ai/backend/issues/47

Recently the logo file was [changed](https://github.com/tradingstrategy-ai/frontend/commit/71215b6d197e0aae7d68a4edb383884289894757), and this PR updates the affected URLs accordingly.