### PR TITLE
Fix path to renamed logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
   <div class="wrapper">
     <div class="trading-strategy-top-bar">
       <a class="logo-link" href="https://tradingstrategy.ai">
-        <img src="https://github.com/tradingstrategy-ai/frontend/raw/master/src/lib/assets/logo-horizontal.svg">
+        <img src="https://raw.githubusercontent.com/tradingstrategy-ai/frontend/ec73a013cae04fa3f13c579dcc0dd0d80cbc49cc/src/lib/assets/logo-horizontal.svg">
       </a>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
   <div class="wrapper">
     <div class="trading-strategy-top-bar">
       <a class="logo-link" href="https://tradingstrategy.ai">
-        <img src="https://github.com/tradingstrategy-ai/frontend/raw/master/src/lib/assets/logo-horizontal-light.svg">
+        <img src="https://github.com/tradingstrategy-ai/frontend/raw/master/src/lib/assets/logo-horizontal.svg">
       </a>
     </div>
   </div>

--- a/open-defi-api.yaml
+++ b/open-defi-api.yaml
@@ -8,7 +8,7 @@ info:
     email: mikko@tradingstrategy.ai
     url: 'https://tradingstrategy.ai'
   x-logo:
-    url: 'https://raw.githubusercontent.com/tradingstrategy-ai/frontend/master/src/lib/assets/logo-horizontal-light.svg'
+    url: 'https://raw.githubusercontent.com/tradingstrategy-ai/frontend/master/src/lib/assets/logo-horizontal.svg'
 
   description: |
 

--- a/open-defi-api.yaml
+++ b/open-defi-api.yaml
@@ -8,7 +8,7 @@ info:
     email: mikko@tradingstrategy.ai
     url: 'https://tradingstrategy.ai'
   x-logo:
-    url: 'https://raw.githubusercontent.com/tradingstrategy-ai/frontend/master/src/lib/assets/logo-horizontal.svg'
+    url: 'https://raw.githubusercontent.com/tradingstrategy-ai/frontend/ec73a013cae04fa3f13c579dcc0dd0d80cbc49cc/src/lib/assets/logo-horizontal.svg'
 
   description: |
 

--- a/trade-executor-api.yaml
+++ b/trade-executor-api.yaml
@@ -8,7 +8,7 @@ info:
     email: mikko@tradingstrategy.ai
     url: 'https://tradingstrategy.ai'
   x-logo:
-    url: 'https://raw.githubusercontent.com/tradingstrategy-ai/frontend/master/src/lib/assets/logo-horizontal-light.svg'
+    url: 'https://raw.githubusercontent.com/tradingstrategy-ai/frontend/master/src/lib/assets/logo-horizontal.svg'
 
   description: |
 

--- a/trade-executor-api.yaml
+++ b/trade-executor-api.yaml
@@ -8,7 +8,7 @@ info:
     email: mikko@tradingstrategy.ai
     url: 'https://tradingstrategy.ai'
   x-logo:
-    url: 'https://raw.githubusercontent.com/tradingstrategy-ai/frontend/master/src/lib/assets/logo-horizontal.svg'
+    url: 'https://raw.githubusercontent.com/tradingstrategy-ai/frontend/ec73a013cae04fa3f13c579dcc0dd0d80cbc49cc/src/lib/assets/logo-horizontal.svg'
 
   description: |
 


### PR DESCRIPTION
Fixes https://github.com/tradingstrategy-ai/backend/issues/56

The logo has been renamed again in the frontend repo:
https://github.com/tradingstrategy-ai/frontend/tree/master/src/lib/assets