### PR TITLE
Fix token_addresses serialization style in /pairs

### DIFF
--- a/open-defi-api.yaml
+++ b/open-defi-api.yaml
@@ -514,7 +514,7 @@ paths:
         - name: token_addresses
           in: query
           style: form
-          explode: true
+          explode: false
           description: |
             For querying trading pairs for a specific token.
 


### PR DESCRIPTION
The backend expects a comma-separated list, but the API specs were not rendered correctly, they generated the URL by repeating the token_addresses query string param.