### PR TITLE
Lending reserves return 200 OK when no data found

### DIFF
--- a/open-defi-api.yaml
+++ b/open-defi-api.yaml
@@ -1380,8 +1380,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedReserveInfo'
-        "404":
-          description: No reserve data found for the lending protocol.
         "422":
           description: Unexpected error - usually bad query input.
           content:


### PR DESCRIPTION
Towards https://github.com/tradingstrategy-ai/backend/issues/188

As per request, the endpoint should return 200 OK and an empty dataset, rather than 404 NOT FOUND.